### PR TITLE
Creates first iteration at debugger

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -116,7 +116,17 @@ rec {
         ];
         
       };
-      "arrayvec" = rec {
+      "arrayref" = rec {
+        crateName = "arrayref";
+        version = "0.3.6";
+        edition = "2015";
+        sha256 = "0i6m1l3f73i0lf0cjdf5rh3xpvxydyhfbakq7xx7bkrp5qajgid4";
+        authors = [
+          "David Roundy <roundyd@physics.oregonstate.edu>"
+        ];
+        
+      };
+      "arrayvec 0.4.12" = rec {
         crateName = "arrayvec";
         version = "0.4.12";
         edition = "2015";
@@ -136,6 +146,18 @@ rec {
           "serde-1" = [ "serde" ];
         };
         resolvedDefaultFeatures = [ "array-sizes-33-128" "default" "std" ];
+      };
+      "arrayvec 0.5.1" = rec {
+        crateName = "arrayvec";
+        version = "0.5.1";
+        edition = "2018";
+        sha256 = "1f5mca8kiiwhvhxd1mbnq68j6v6rk139sch567zwwzl6hs37vxyg";
+        authors = [
+          "bluss"
+        ];
+        features = {
+          "default" = [ "std" ];
+        };
       };
       "atty" = rec {
         crateName = "atty";
@@ -231,6 +253,20 @@ rec {
         ];
         
       };
+      "base64" = rec {
+        crateName = "base64";
+        version = "0.11.0";
+        edition = "2018";
+        sha256 = "1iqmims6yvr6vwzyy54qd672zw29ipjj17p8klcr578c9ajpw6xl";
+        authors = [
+          "Alice Maz <alice@alicemaz.com>"
+          "Marshall Pierce <marshall@mpierce.org>"
+        ];
+        features = {
+          "default" = [ "std" ];
+        };
+        resolvedDefaultFeatures = [ "default" "std" ];
+      };
       "bit-set" = rec {
         crateName = "bit-set";
         version = "0.5.1";
@@ -278,6 +314,34 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" ];
       };
+      "blake2b_simd" = rec {
+        crateName = "blake2b_simd";
+        version = "0.5.10";
+        edition = "2018";
+        sha256 = "12icvk8ixlivv3jv5nyrg01sajp4s279zb1kmif0nfja4ms2vyyq";
+        authors = [
+          "Jack O'Connor"
+        ];
+        dependencies = [
+          {
+            name = "arrayref";
+            packageId = "arrayref";
+          }
+          {
+            name = "arrayvec";
+            packageId = "arrayvec 0.5.1";
+            usesDefaultFeatures = false;
+          }
+          {
+            name = "constant_time_eq";
+            packageId = "constant_time_eq";
+          }
+        ];
+        features = {
+          "default" = [ "std" ];
+        };
+        resolvedDefaultFeatures = [ "default" "std" ];
+      };
       "bumpalo" = rec {
         crateName = "bumpalo";
         version = "3.2.1";
@@ -313,6 +377,19 @@ rec {
           "default" = [ "std" ];
         };
         resolvedDefaultFeatures = [ "default" "std" ];
+      };
+      "cc" = rec {
+        crateName = "cc";
+        version = "1.0.50";
+        edition = "2018";
+        crateBin = [];
+        sha256 = "1kdqm8ka7xg9h56b694pcz29ka33fsz27mzrphqc78gx96h8zqlm";
+        authors = [
+          "Alex Crichton <alex@alexcrichton.com>"
+        ];
+        features = {
+          "parallel" = [ "jobserver" ];
+        };
       };
       "cfg-if" = rec {
         crateName = "cfg-if";
@@ -428,6 +505,16 @@ rec {
             name = "wasm-bindgen";
             packageId = "wasm-bindgen";
           }
+        ];
+        
+      };
+      "constant_time_eq" = rec {
+        crateName = "constant_time_eq";
+        version = "0.1.5";
+        edition = "2015";
+        sha256 = "1g3vp04qzmk6cpzrd19yci6a95m7ap6wy7wkwgiy2pjklklrfl14";
+        authors = [
+          "Cesar Eduardo Barros <cesarb@cesarb.eti.br>"
         ];
         
       };
@@ -583,6 +670,38 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "lazy_static" "std" ];
       };
+      "ctrlc" = rec {
+        crateName = "ctrlc";
+        version = "3.1.4";
+        edition = "2015";
+        sha256 = "19qps8xw9vpsssrhn6rn46scx66gn0811kinjqf4ryprvy3acjvs";
+        authors = [
+          "Antti Keränen <detegr@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "nix";
+            packageId = "nix";
+            target = { target, features }: target."unix";
+          }
+          {
+            name = "winapi";
+            packageId = "winapi";
+            target = { target, features }: target."windows";
+            features = [ "consoleapi" "handleapi" "synchapi" "winbase" ];
+          }
+        ];
+        devDependencies = [
+          {
+            name = "winapi";
+            packageId = "winapi";
+            target = {target, features}: target."windows";
+            features = [ "fileapi" "processenv" "winnt" ];
+          }
+        ];
+        features = {
+        };
+      };
       "deflate" = rec {
         crateName = "deflate";
         version = "0.8.4";
@@ -604,6 +723,58 @@ rec {
         features = {
           "gzip" = [ "gzip-header" ];
         };
+      };
+      "dirs" = rec {
+        crateName = "dirs";
+        version = "2.0.2";
+        edition = "2015";
+        sha256 = "1qymhyq7w7wlf1dirq6gsnabdyzg6yi2yyxkx6c4ldlkbjdaibhk";
+        authors = [
+          "Simon Ochsenreither <simon@ochsenreither.de>"
+        ];
+        dependencies = [
+          {
+            name = "cfg-if";
+            packageId = "cfg-if";
+          }
+          {
+            name = "dirs-sys";
+            packageId = "dirs-sys";
+          }
+        ];
+        
+      };
+      "dirs-sys" = rec {
+        crateName = "dirs-sys";
+        version = "0.3.4";
+        edition = "2015";
+        sha256 = "0yyykdcmbc476z1v9m4z5jb8y91dw6kgzpkiqi2ig07xx0yv585g";
+        authors = [
+          "Simon Ochsenreither <simon@ochsenreither.de>"
+        ];
+        dependencies = [
+          {
+            name = "cfg-if";
+            packageId = "cfg-if";
+          }
+          {
+            name = "libc";
+            packageId = "libc";
+            target = { target, features }: target."unix";
+          }
+          {
+            name = "redox_users";
+            packageId = "redox_users";
+            target = { target, features }: (target."os" == "redox");
+          }
+          {
+            name = "winapi";
+            packageId = "winapi";
+            target = { target, features }: target."windows";
+            features = [ "knownfolders" "objbase" "shlobj" "winbase" "winerror" ];
+          }
+        ];
+        
       };
       "either" = rec {
         crateName = "either";
@@ -970,6 +1141,11 @@ rec {
             optional = true;
           }
           {
+            name = "ctrlc";
+            packageId = "ctrlc";
+            target = { target, features }: target."unix";
+          }
+          {
             name = "illicit";
             packageId = "illicit";
           }
@@ -1003,6 +1179,16 @@ rec {
             packageId = "packed_struct_codegen";
           }
           {
+            name = "rustyline";
+            packageId = "rustyline";
+            target = { target, features }: target."unix";
+          }
+          {
+            name = "rustyline-derive";
+            packageId = "rustyline-derive";
+            target = { target, features }: target."unix";
+          }
+          {
             name = "serde";
             packageId = "serde";
             target = { target, features }: target."unix";
@@ -1011,6 +1197,11 @@ rec {
           {
             name = "serde_json";
             packageId = "serde_json";
+            target = { target, features }: target."unix";
+          }
+          {
+            name = "shlex";
+            packageId = "shlex";
             target = { target, features }: target."unix";
           }
           {
@@ -1367,7 +1558,7 @@ rec {
         dependencies = [
           {
             name = "arrayvec";
-            packageId = "arrayvec";
+            packageId = "arrayvec 0.4.12";
             optional = true;
             features = [ "array-sizes-33-128" ];
           }
@@ -1411,7 +1602,7 @@ rec {
           "rustc-dep-of-std" = [ "align" "rustc-std-workspace-core" ];
           "use_std" = [ "std" ];
         };
-        resolvedDefaultFeatures = [ "default" "std" ];
+        resolvedDefaultFeatures = [ "default" "extra_traits" "std" ];
       };
       "lock_api" = rec {
         crateName = "lock_api";
@@ -1676,6 +1867,42 @@ rec {
           "webdom" = [ "augdom/webdom" "raf" ];
         };
         resolvedDefaultFeatures = [ "default" "raf" "webdom" ];
+      };
+      "nix" = rec {
+        crateName = "nix";
+        version = "0.17.0";
+        edition = "2015";
+        sha256 = "0qvk09kib3jpvpbaps0682nav20ibql61pf1s2h8jx9v5igpir2h";
+        authors = [
+          "The nix-rust Project Developers"
+        ];
+        dependencies = [
+          {
+            name = "bitflags";
+            packageId = "bitflags";
+          }
+          {
+            name = "cfg-if";
+            packageId = "cfg-if";
+          }
+          {
+            name = "libc";
+            packageId = "libc";
+            features = [ "extra_traits" ];
+          }
+          {
+            name = "void";
+            packageId = "void";
+          }
+        ];
+        buildDependencies = [
+          {
+            name = "cc";
+            packageId = "cc";
+            target = {target, features}: (target."os" == "dragonfly");
+          }
+        ];
+        
       };
       "nodrop" = rec {
         crateName = "nodrop";
@@ -2912,6 +3139,31 @@ rec {
         ];
         
       };
+      "redox_users" = rec {
+        crateName = "redox_users";
+        version = "0.3.4";
+        edition = "2015";
+        sha256 = "0cbl5w16l3bqm22i4vszclf6hzpljxicghmllw7j13az4s9k1ch9";
+        authors = [
+          "Jose Narvaez <goyox86@gmail.com>"
+          "Wesley Hershberger <mggmugginsmc@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "getrandom";
+            packageId = "getrandom";
+          }
+          {
+            name = "redox_syscall";
+            packageId = "redox_syscall";
+          }
+          {
+            name = "rust-argon2";
+            packageId = "rust-argon2";
+          }
+        ];
+        
+      };
       "regex-syntax" = rec {
         crateName = "regex-syntax";
         version = "0.6.17";
@@ -2940,6 +3192,35 @@ rec {
             packageId = "winapi";
             target = { target, features }: target."windows";
             features = [ "std" "errhandlingapi" "winerror" "fileapi" "winbase" ];
+          }
+        ];
+        
+      };
+      "rust-argon2" = rec {
+        crateName = "rust-argon2";
+        version = "0.7.0";
+        edition = "2018";
+        sha256 = "05xh5wfxgzq3b6jys8r34f3hmqqfs8ylvf934n9z87wfv95szj1b";
+        libName = "argon2";
+        authors = [
+          "Martijn Rijkeboer <mrr@sru-systems.com>"
+        ];
+        dependencies = [
+          {
+            name = "base64";
+            packageId = "base64";
+          }
+          {
+            name = "blake2b_simd";
+            packageId = "blake2b_simd";
+          }
+          {
+            name = "constant_time_eq";
+            packageId = "constant_time_eq";
+          }
+          {
+            name = "crossbeam-utils";
+            packageId = "crossbeam-utils";
           }
         ];
         
@@ -2992,6 +3273,89 @@ rec {
           "timeout" = [ "wait-timeout" ];
         };
         resolvedDefaultFeatures = [ "timeout" "wait-timeout" ];
+      };
+      "rustyline" = rec {
+        crateName = "rustyline";
+        version = "6.1.1";
+        edition = "2018";
+        sha256 = "0cn3vmvy5q6q2gn7hygivb70nsw15jc24b7gcg8np1fshi53i9v1";
+        authors = [
+          "Katsu Kawakami <kkawa1570@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "cfg-if";
+            packageId = "cfg-if";
+          }
+          {
+            name = "dirs";
+            packageId = "dirs";
+            optional = true;
+          }
+          {
+            name = "libc";
+            packageId = "libc";
+          }
+          {
+            name = "log";
+            packageId = "log";
+          }
+          {
+            name = "memchr";
+            packageId = "memchr";
+          }
+          {
+            name = "nix";
+            packageId = "nix";
+            target = { target, features }: target."unix";
+          }
+          {
+            name = "unicode-segmentation";
+            packageId = "unicode-segmentation";
+          }
+          {
+            name = "unicode-width";
+            packageId = "unicode-width";
+          }
+          {
+            name = "utf8parse";
+            packageId = "utf8parse";
+            target = { target, features }: target."unix";
+          }
+          {
+            name = "winapi";
+            packageId = "winapi";
+            target = { target, features }: target."windows";
+            features = [ "consoleapi" "handleapi" "minwindef" "processenv" "winbase" "wincon" "winuser" ];
+          }
+        ];
+        features = {
+          "default" = [ "with-dirs" ];
+          "with-dirs" = [ "dirs" ];
+          "with-fuzzy" = [ "skim" ];
+        };
+        resolvedDefaultFeatures = [ "default" "dirs" "with-dirs" ];
+      };
+      "rustyline-derive" = rec {
+        crateName = "rustyline-derive";
+        version = "0.3.1";
+        edition = "2018";
+        sha256 = "0daj9szvfi442vj2fhm7qb92wmzv7g75qsjq9a6ycnqac4lhx9al";
+        procMacro = true;
+        authors = [
+          "gwenn"
+        ];
+        dependencies = [
+          {
+            name = "quote";
+            packageId = "quote 1.0.3";
+          }
+          {
+            name = "syn";
+            packageId = "syn 1.0.17";
+          }
+        ];
+        
       };
       "ryu" = rec {
         crateName = "ryu";
@@ -3147,6 +3511,16 @@ rec {
           "std" = [ "serde/std" ];
         };
         resolvedDefaultFeatures = [ "default" "std" ];
+      };
+      "shlex" = rec {
+        crateName = "shlex";
+        version = "0.1.1";
+        edition = "2015";
+        sha256 = "1lmv6san7g8dv6jdfp14m7bdczq9ss7j7bgsfqyqjc3jnjfippvz";
+        authors = [
+          "comex <comexk@gmail.com>"
+        ];
+        
       };
       "slab" = rec {
         crateName = "slab";
@@ -3752,6 +4126,19 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" ];
       };
+      "utf8parse" = rec {
+        crateName = "utf8parse";
+        version = "0.2.0";
+        edition = "2018";
+        sha256 = "0wjkvy22cxg023vkmvq2wwkgqyqam0d4pjld3m13blfg594lnvlk";
+        authors = [
+          "Joe Wilm <joe@jwilm.com>"
+          "Christian Duerr <contact@christianduerr.com>"
+        ];
+        features = {
+        };
+        resolvedDefaultFeatures = [ "default" ];
+      };
       "vec_map" = rec {
         crateName = "vec_map";
         version = "0.8.1";
@@ -3798,6 +4185,19 @@ rec {
           "Sergio Benitez <sb@sergio.bz>"
         ];
         
+      };
+      "void" = rec {
+        crateName = "void";
+        version = "1.0.2";
+        edition = "2015";
+        sha256 = "0zc8f0ksxvmhvgx4fdg0zyn6vdnbxd2xv9hfx4nhzg6kbs4f80ka";
+        authors = [
+          "Jonathan Reem <jonathan.reem@gmail.com>"
+        ];
+        features = {
+          "default" = [ "std" ];
+        };
+        resolvedDefaultFeatures = [ "default" "std" ];
       };
       "wait-timeout" = rec {
         crateName = "wait-timeout";
@@ -4467,7 +4867,7 @@ rec {
         features = {
           "debug" = [ "impl-debug" ];
         };
-        resolvedDefaultFeatures = [ "consoleapi" "errhandlingapi" "fileapi" "handleapi" "memoryapi" "minwinbase" "minwindef" "ntsecapi" "ntstatus" "processenv" "profileapi" "std" "synchapi" "winbase" "winerror" "winnt" ];
+        resolvedDefaultFeatures = [ "consoleapi" "errhandlingapi" "fileapi" "handleapi" "knownfolders" "memoryapi" "minwinbase" "minwindef" "ntsecapi" "ntstatus" "objbase" "processenv" "profileapi" "shlobj" "std" "synchapi" "winbase" "wincon" "winerror" "winnt" "winuser" ];
       };
       "winapi-i686-pc-windows-gnu" = rec {
         crateName = "winapi-i686-pc-windows-gnu";

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -1184,11 +1184,6 @@ rec {
             target = { target, features }: target."unix";
           }
           {
-            name = "rustyline-derive";
-            packageId = "rustyline-derive";
-            target = { target, features }: target."unix";
-          }
-          {
             name = "serde";
             packageId = "serde";
             target = { target, features }: target."unix";
@@ -3335,27 +3330,6 @@ rec {
           "with-fuzzy" = [ "skim" ];
         };
         resolvedDefaultFeatures = [ "default" "dirs" "with-dirs" ];
-      };
-      "rustyline-derive" = rec {
-        crateName = "rustyline-derive";
-        version = "0.3.1";
-        edition = "2018";
-        sha256 = "0daj9szvfi442vj2fhm7qb92wmzv7g75qsjq9a6ycnqac4lhx9al";
-        procMacro = true;
-        authors = [
-          "gwenn"
-        ];
-        dependencies = [
-          {
-            name = "quote";
-            packageId = "quote 1.0.3";
-          }
-          {
-            name = "syn";
-            packageId = "syn 1.0.17";
-          }
-        ];
-        
       };
       "ryu" = rec {
         crateName = "ryu";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ image = "0.23.3"
 serde_json = "1.0"
 ansi-escapes = "0.1"
 rustyline = "6.1"
-rustyline-derive = "0.3"
 shlex = "0.1.1"
 ctrlc = "3.1.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ structopt = "0.3"
 image = "0.23.3"
 serde_json = "1.0"
 ansi-escapes = "0.1"
+rustyline = "6.1"
+rustyline-derive = "0.3"
+shlex = "0.1.1"
+ctrlc = "3.1.4"
 
 [target.'cfg(unix)'.dependencies.serde]
 version = "1.0"

--- a/shell.nix
+++ b/shell.nix
@@ -10,5 +10,6 @@ pkgs.mkShell {
     rust
     pkgs.dhall
     pkgs.dhall-json
+    pkgs.wla-dx
   ] ++ (if pkgs.stdenv.isDarwin then [ pkgs.darwin.apple_sdk.frameworks.Security ] else []);
 }

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -1,0 +1,609 @@
+use std::borrow::Cow::{self, Borrowed, Owned};
+
+use hardware::{self, Hardware};
+use headless;
+use rustyline::completion::{Completer, FilenameCompleter, Pair};
+use rustyline::config::OutputStreamType;
+use rustyline::error::ReadlineError;
+use rustyline::highlight::{Highlighter, MatchingBracketHighlighter};
+use rustyline::hint::{Hinter, HistoryHinter};
+use rustyline::validate::{self, MatchingBracketValidator, Validator};
+use rustyline::{Cmd, CompletionType, Config, Context, EditMode, Editor, KeyPress};
+use rustyline_derive::Helper;
+use shlex;
+use std::env;
+use std::iter::Extend;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::sync::mpsc::TryRecvError;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::thread::sleep;
+use std::time::Duration;
+use structopt::StructOpt;
+use these::These;
+use web_utils::Performance;
+
+/*
+ * INFO:
+ * print [-s --screen | -t --tiles | <expr>]
+ * watch [-c --condition <expr> | --name <string>] <expr>
+ * backtrace
+ * break
+ *
+ * MUTATE:
+ * run <file>
+ * break [-d --delete | --name <string>] $<addr> | (<expr>) | <symbol>
+ * continue
+ * step-over
+ * step-into
+ *
+ * EXPR:
+ * literal := $[0-9]+ | 0x[0-9]+ | [0-9]+ (u16)
+ * binop := =, !=, <, >, +, -, *, >>, <<, &, |
+ * registers := A B C D E H L SP PC AF BC DE HL
+ * memory load := [ <register> | <literal> ]
+ */
+
+mod expr {
+    use register_kind::{RegisterKind16, RegisterKind8};
+
+    #[derive(Debug, Clone, Copy)]
+    pub enum Op {
+        Equals,
+        NotEquals,
+        LessThan,
+        GreaterThan,
+        Plus,
+        Minus,
+        Times,
+        RightShift,
+        LeftShift,
+        BitAnd,
+        BitOr,
+    }
+
+    #[derive(Debug, Clone)]
+    pub enum Loadable {
+        Lit(u16),
+        Reg16(RegisterKind16),
+    }
+
+    #[derive(Debug, Clone)]
+    pub enum Term {
+        Reg8(RegisterKind8),
+        Load(Loadable),
+        Loadable(Loadable),
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct E0 {
+        term: Term,
+        e1: Box<E1>,
+    }
+
+    #[derive(Debug, Clone)]
+    pub enum E1 {
+        Epsilon,
+        Binop(Op, Box<E0>, Box<E1>),
+    }
+
+    use nom::{
+        branch::alt,
+        bytes::complete::{tag, tag_no_case, take, take_while, take_while1},
+        character::{is_digit, is_hex_digit, is_space},
+        combinator::{all_consuming, map, map_res, opt},
+        error::{ParseError, VerboseError},
+        multi::count,
+        sequence::{delimited, pair, preceded, terminated, tuple},
+        IResult,
+    };
+
+    fn from_hex8(input: &str) -> Result<u8, std::num::ParseIntError> {
+        u8::from_str_radix(input, 16)
+    }
+
+    fn from_hex16(input: &str) -> Result<u16, std::num::ParseIntError> {
+        u16::from_str_radix(input, 16)
+    }
+
+    fn from_decimal16(input: &str) -> Result<u16, std::num::ParseIntError> {
+        u16::from_str_radix(input, 10)
+    }
+
+    type In<'a> = &'a str;
+
+    fn sp<'a, E: ParseError<&'a str>>(input: In<'a>) -> IResult<In<'a>, In<'a>, E> {
+        take_while(|c| is_space(c as u8))(input)
+    }
+
+    fn op<'a, E: ParseError<&'a str>>(input: In<'a>) -> IResult<In<'a>, Op, E> {
+        preceded(
+            sp,
+            alt((
+                map(tag("="), |_: &str| Op::Equals),
+                map(tag("!="), |_: &str| Op::NotEquals),
+                map(tag("<"), |_: &str| Op::LessThan),
+                map(tag(">"), |_: &str| Op::GreaterThan),
+                map(tag("+"), |_: &str| Op::Plus),
+                map(tag("-"), |_: &str| Op::Minus),
+                map(tag("*"), |_: &str| Op::Times),
+                map(tag(">>"), |_: &str| Op::RightShift),
+                map(tag("<<"), |_: &str| Op::LeftShift),
+                map(tag("&"), |_: &str| Op::BitAnd),
+                map(tag("|"), |_: &str| Op::BitOr),
+            )),
+        )(input)
+    }
+
+    fn lit<'a, E: ParseError<&'a str>>(input: In<'a>) -> IResult<In<'a>, u16, E> {
+        preceded(
+            sp,
+            alt((
+                preceded(
+                    tag("$"),
+                    map_res(take_while1(|c| is_hex_digit(c as u8)), from_hex16),
+                ),
+                preceded(
+                    tag("0x"),
+                    map_res(take_while1(|c| is_hex_digit(c as u8)), from_hex16),
+                ),
+                map_res(take_while1(|c| is_digit(c as u8)), from_decimal16),
+            )),
+        )(input)
+    }
+
+    fn reg16<'a, E: ParseError<&'a str>>(input: In<'a>) -> IResult<In<'a>, RegisterKind16, E> {
+        preceded(
+            sp,
+            alt((
+                map(tag("BC"), |_: &str| RegisterKind16::Bc),
+                map(tag("DE"), |_: &str| RegisterKind16::De),
+                map(tag("HL"), |_: &str| RegisterKind16::Hl),
+                map(tag("SP"), |_: &str| RegisterKind16::Sp),
+            )),
+        )(input)
+    }
+
+    fn loadable<'a, E: ParseError<&'a str>>(input: In<'a>) -> IResult<In<'a>, Loadable, E> {
+        preceded(
+            sp,
+            alt((
+                map(lit, |l: u16| Loadable::Lit(l)),
+                map(reg16, |r: RegisterKind16| Loadable::Reg16(r)),
+            )),
+        )(input)
+    }
+
+    fn load<'a, E: ParseError<&'a str>>(input: In<'a>) -> IResult<In<'a>, Loadable, E> {
+        delimited(
+            preceded(sp, tag("[")),
+            preceded(sp, loadable),
+            preceded(sp, tag("]")),
+        )(input)
+    }
+
+    fn reg8<'a, E: ParseError<&'a str>>(input: In<'a>) -> IResult<In<'a>, RegisterKind8, E> {
+        preceded(
+            sp,
+            alt((
+                map(tag("A"), |_: &str| RegisterKind8::A),
+                map(tag("B"), |_: &str| RegisterKind8::B),
+                map(tag("C"), |_: &str| RegisterKind8::C),
+                map(tag("D"), |_: &str| RegisterKind8::D),
+                map(tag("E"), |_: &str| RegisterKind8::E),
+                map(tag("H"), |_: &str| RegisterKind8::H),
+                map(tag("L"), |_: &str| RegisterKind8::L),
+            )),
+        )(input)
+    }
+
+    fn term<'a, E: ParseError<&'a str>>(input: In<'a>) -> IResult<In<'a>, Term, E> {
+        preceded(
+            sp,
+            alt((
+                map(load, |l: Loadable| Term::Load(l)),
+                map(loadable, |l: Loadable| Term::Loadable(l)),
+                map(reg8, |r: RegisterKind8| Term::Reg8(r)),
+            )),
+        )(input)
+    }
+
+    fn expr0<'a, E: ParseError<&'a str>>(input: In<'a>) -> IResult<In<'a>, Box<E0>, E> {
+        let (input, term) = term(input)?;
+        let (input, e1) = expr1(input)?;
+        Ok((input, Box::new(E0 { term, e1 })))
+    }
+
+    fn expr1<'a, E: ParseError<&'a str>>(input: In<'a>) -> IResult<In<'a>, Box<E1>, E> {
+        map(
+            alt((
+                map(tuple((op, expr0, expr1)), |(op, e0, e1)| {
+                    E1::Binop(op, e0, e1)
+                }),
+                map(take(0u8), |_: &str| E1::Epsilon),
+            )),
+            |e1| Box::new(e1),
+        )(input)
+    }
+
+    fn root<'a, E: ParseError<&'a str>>(input: In<'a>) -> IResult<In<'a>, Box<E0>, E> {
+        all_consuming(expr0)(input)
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct E(pub Box<E0>);
+    impl std::str::FromStr for E {
+        type Err = std::string::String;
+
+        fn from_str(src: &str) -> Result<E, Self::Err> {
+            root::<VerboseError<&str>>(src)
+                .map(|(_, e0)| E(e0))
+                .map_err(|e| match e {
+                    nom::Err::Error(e) => nom::error::convert_error(src, e),
+                    nom::Err::Failure(e) => nom::error::convert_error(src, e),
+                    nom::Err::Incomplete(_) => "Incomplete".to_string(),
+                })
+        }
+    }
+
+    use hardware::Hardware;
+    use mem::Addr;
+
+    pub type Output = u16;
+    type Context<'a> = &'a mut Hardware;
+    pub trait Eval {
+        fn eval(&self, ctx: Context) -> Output;
+    }
+
+    impl Eval for Loadable {
+        fn eval(&self, ctx: Context) -> Output {
+            match self {
+                Loadable::Lit(lit) => *lit,
+                Loadable::Reg16(rk) => ctx.cpu.registers.read16(*rk).0,
+            }
+        }
+    }
+
+    impl Eval for Term {
+        fn eval(&self, ctx: Context) -> Output {
+            match self {
+                Term::Reg8(rk) => u16::from(ctx.cpu.registers.read8(*rk).0),
+                Term::Loadable(loadable) => loadable.eval(ctx),
+                Term::Load(loadable) => {
+                    let res = loadable.eval(ctx);
+                    u16::from(ctx.cpu.memory.ld8(Addr::directly(res)))
+                }
+            }
+        }
+    }
+
+    impl Eval for E0 {
+        fn eval(&self, ctx: Context) -> Output {
+            fn f(l: Output, op: &Op, r: Output) -> Output {
+                match op {
+                    Op::Equals => {
+                        if l == r {
+                            0
+                        } else {
+                            1
+                        }
+                    }
+                    Op::NotEquals => {
+                        if l != r {
+                            0
+                        } else {
+                            1
+                        }
+                    }
+                    Op::LessThan => {
+                        if l < r {
+                            0
+                        } else {
+                            1
+                        }
+                    }
+                    Op::GreaterThan => {
+                        if l > r {
+                            0
+                        } else {
+                            1
+                        }
+                    }
+                    Op::Plus => l + r,
+                    Op::Minus => l - r,
+                    Op::Times => l * r,
+                    Op::RightShift => l >> r,
+                    Op::LeftShift => l << r,
+                    Op::BitAnd => l & r,
+                    Op::BitOr => l | r,
+                }
+            }
+
+            fn go(ctx: Context, acc: Output, e1: &Box<E1>) -> Output {
+                match e1 {
+                    box E1::Epsilon => acc,
+                    box E1::Binop(op, e0, e1) => {
+                        let e0_ = e0.eval(ctx);
+                        go(ctx, f(acc, op, e0_), e1)
+                    }
+                }
+            }
+
+            let t1 = self.term.eval(ctx);
+            go(ctx, t1, &self.e1)
+        }
+    }
+
+    impl Eval for E {
+        fn eval(&self, ctx: Context) -> Output {
+            self.0.eval(ctx)
+        }
+    }
+}
+
+#[derive(Debug, StructOpt)]
+#[structopt(about = "Debugger line for the gameboy")]
+enum Line {
+    Print {
+        #[structopt(short, long)]
+        screen: bool,
+        #[structopt(short, long)]
+        tiles: bool,
+        #[structopt(parse(try_from_str))]
+        expr: Option<expr::E>,
+    },
+    /// Print the result of the expression after every command
+    Watch {
+        #[structopt(short, long)]
+        condition: Option<String>,
+        #[structopt(short, long)]
+        name: Option<String>,
+        #[structopt(parse(try_from_str))]
+        expr: Option<expr::E>,
+    },
+    Backtrace,
+    /// Set or print breakpoints
+    Break {
+        #[structopt(short, long)]
+        delete: bool,
+        #[structopt(short, long)]
+        name: Option<String>,
+        /// Args are $<addr> | (<expr>) | <symbol>
+        #[structopt(name = "ARG")]
+        arg: Option<String>,
+    },
+    /// Continue running
+    Continue,
+    /// Step-over
+    StepOver,
+    /// Step-into
+    StepInto,
+}
+
+#[derive(Helper)]
+struct MyHelper {
+    completer: FilenameCompleter,
+    highlighter: MatchingBracketHighlighter,
+    validator: MatchingBracketValidator,
+    hinter: HistoryHinter,
+    colored_prompt: String,
+}
+
+impl Completer for MyHelper {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        ctx: &Context<'_>,
+    ) -> Result<(usize, Vec<Pair>), ReadlineError> {
+        self.completer.complete(line, pos, ctx)
+    }
+}
+
+impl Hinter for MyHelper {
+    fn hint(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<String> {
+        self.hinter.hint(line, pos, ctx)
+    }
+}
+
+impl Highlighter for MyHelper {
+    fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
+        &'s self,
+        prompt: &'p str,
+        default: bool,
+    ) -> Cow<'b, str> {
+        if default {
+            Borrowed(&self.colored_prompt)
+        } else {
+            Borrowed(prompt)
+        }
+    }
+
+    fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
+        Owned("\x1b[1m".to_owned() + hint + "\x1b[m")
+    }
+
+    fn highlight<'l>(&self, line: &'l str, pos: usize) -> Cow<'l, str> {
+        self.highlighter.highlight(line, pos)
+    }
+
+    fn highlight_char(&self, line: &str, pos: usize) -> bool {
+        self.highlighter.highlight_char(line, pos)
+    }
+}
+
+impl Validator for MyHelper {
+    fn validate(
+        &self,
+        ctx: &mut validate::ValidationContext,
+    ) -> rustyline::Result<validate::ValidationResult> {
+        self.validator.validate(ctx)
+    }
+
+    fn validate_while_typing(&self) -> bool {
+        self.validator.validate_while_typing()
+    }
+}
+
+fn exec_until_interrupt(
+    performance: &Performance,
+    hardware: &mut Hardware,
+    running: Arc<AtomicBool>,
+) {
+    // timing
+    let start = performance.now();
+    let mut last = start;
+
+    running.store(true, Ordering::SeqCst);
+    loop {
+        if running.load(Ordering::SeqCst) {
+            let now = performance.now();
+            let diff = now - last;
+            last = now;
+
+            hardware.run(diff);
+
+            let now_ = performance.now();
+            sleep(Duration::from_micros(
+                16_667 - (((now_ - now) * 1000.) as u64),
+            ))
+        } else {
+            break;
+        }
+    }
+}
+
+fn icat(img: &Path) {
+    let mut process = Command::new("kitty")
+        .arg("+kitten")
+        .arg("icat")
+        .arg(img.to_str().unwrap())
+        .spawn();
+    match process.iter_mut().next() {
+        Some(p) => {
+            let _ = p.wait();
+        }
+        None => (),
+    };
+}
+
+fn cmd(performance: &Performance, hardware: &mut Hardware, running: Arc<AtomicBool>, line: Line) {
+    use self::expr::Eval;
+
+    match line {
+        Line::Print {
+            screen,
+            tiles,
+            expr,
+        } => {
+            if screen {
+                let mut dir = env::temp_dir();
+                dir.push("screenshot.png");
+                let path = Path::new(&dir);
+                headless::save_screenshot(&path, &hardware.ppu.screen);
+                icat(&path);
+            }
+            if tiles {
+                println!("TODO: Dump tiles");
+            }
+
+            match expr {
+                Some(e) => {
+                    let res: u16 = e.eval(hardware);
+                    println!("  {:}", res)
+                }
+                None => (),
+            }
+        }
+        Line::Continue => exec_until_interrupt(performance, hardware, running),
+        _ => println!("Line: {:?}", line),
+    }
+}
+
+pub fn run(rom: &PathBuf) {
+    let running = Arc::new(AtomicBool::new(true));
+    let r = running.clone();
+
+    let config = Config::builder()
+        .history_ignore_space(true)
+        .completion_type(CompletionType::List)
+        .edit_mode(EditMode::Vi)
+        .output_stream(OutputStreamType::Stdout)
+        .build();
+    let h = MyHelper {
+        completer: FilenameCompleter::new(),
+        highlighter: MatchingBracketHighlighter::new(),
+        hinter: HistoryHinter {},
+        colored_prompt: "".to_owned(),
+        validator: MatchingBracketValidator::new(),
+    };
+    let mut rl = Editor::with_config(config);
+    rl.set_helper(Some(h));
+    rl.bind_sequence(KeyPress::Ctrl('R'), Cmd::ReverseSearchHistory);
+    rl.bind_sequence(KeyPress::Tab, Cmd::CompleteHint);
+
+    let performance = Performance::create();
+
+    let cartridge = headless::read_cartridge(rom);
+
+    let mut hardware = Hardware::create(
+        &performance,
+        hardware::Config {
+            trace: false,
+            roms: These::That(Cow::Owned(cartridge)),
+        },
+    );
+    hardware.paused = false;
+
+    ctrlc::set_handler(move || {
+        println!("Interrupted 1");
+        r.store(false, Ordering::SeqCst);
+    })
+    .expect("Error setting Ctrl-C handler");
+
+    let mut count = 0;
+    loop {
+        let p = format!("{}> ", count);
+        rl.helper_mut().expect("No helper").colored_prompt = format!("\x1b[1;32m{}\x1b[0m", p);
+        let readline = rl.readline(&p);
+
+        // let readline = rl.readline("(debug) \x1b[1m𝝺 \x1b[0m");
+        match readline {
+            Ok(line) => {
+                rl.add_history_entry(line.as_str());
+                match shlex::split(line.as_str()) {
+                    None => println!(""),
+                    Some(ys) => {
+                        let mut xs = vec!["gameboy-debugger".to_string()];
+                        xs.extend(ys);
+                        let l = Line::from_iter_safe(xs);
+                        match l {
+                            Ok(line) => {
+                                cmd(&performance, &mut hardware, running.clone(), line);
+                            }
+                            Err(e) => println!("Line: {:}", e),
+                        }
+                    }
+                }
+            }
+            Err(ReadlineError::Interrupted) => {
+                println!("Interrupted");
+            }
+            Err(ReadlineError::Eof) => {
+                println!("CTRL-D");
+                break;
+            }
+            Err(err) => {
+                println!("Error: {:?}", err);
+                break;
+            }
+        }
+        count += 1;
+    }
+}

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -8,8 +8,7 @@ use rustyline::error::ReadlineError;
 use rustyline::highlight::{Highlighter, MatchingBracketHighlighter};
 use rustyline::hint::{Hinter, HistoryHinter};
 use rustyline::validate::{self, MatchingBracketValidator, Validator};
-use rustyline::{Cmd, CompletionType, Config, Context, EditMode, Editor, KeyPress};
-use rustyline_derive::Helper;
+use rustyline::{Cmd, CompletionType, Config, Context, EditMode, Editor, Helper, KeyPress};
 use shlex;
 use std::env;
 use std::iter::Extend;
@@ -384,7 +383,6 @@ enum Line {
     StepInto,
 }
 
-#[derive(Helper)]
 struct MyHelper {
     completer: FilenameCompleter,
     highlighter: MatchingBracketHighlighter,
@@ -392,6 +390,7 @@ struct MyHelper {
     hinter: HistoryHinter,
     colored_prompt: String,
 }
+impl Helper for MyHelper {}
 
 impl Completer for MyHelper {
     type Candidate = Pair;

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -43,21 +43,22 @@ pub struct Config {
     pub rom: PathBuf,
 }
 
+pub fn save_screenshot(path: &Path, screen: &Screen) {
+    let mut file = File::create(path).expect("Cannot create screenshot");
+    let encoder = PNGEncoder::new(file);
+    encoder
+        .encode(
+            screen.data.as_slice(),
+            screen.width,
+            screen.height,
+            image::ColorType::Rgba8,
+        )
+        .expect("Couldn't write png to file");
+}
+
 fn capture_screenshot(config: &Config, name: &str, screen: &Screen) {
     match &config.screenshot_directory {
-        Some(dir) => {
-            let mut file = File::create(Path::new(dir).join(name.to_owned() + ".png"))
-                .expect("Cannot create screenshot");
-            let encoder = PNGEncoder::new(file);
-            encoder
-                .encode(
-                    screen.data.as_slice(),
-                    screen.width,
-                    screen.height,
-                    image::ColorType::Rgba8,
-                )
-                .expect("Couldn't write png to file");
-        }
+        Some(dir) => save_screenshot(&Path::new(dir).join(name.to_owned() + ".png"), screen),
         None => (),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 #![feature(track_caller)]
 #![feature(exclusive_range_pattern)]
 #![feature(or_patterns)]
+#![feature(box_syntax, box_patterns)]
 #![recursion_limit = "512"]
 
 extern crate packed_struct;
@@ -16,6 +17,10 @@ extern crate these;
 #[macro_use]
 extern crate serde;
 extern crate ansi_escapes;
+extern crate rustyline;
+#[macro_use]
+extern crate rustyline_derive;
+extern crate shlex;
 
 #[cfg(test)]
 pub mod test {
@@ -28,6 +33,7 @@ extern crate image;
 
 mod alu;
 mod cpu;
+mod debugger;
 mod hardware;
 mod headless;
 mod instr;
@@ -83,6 +89,10 @@ enum Config {
         #[structopt(flatten)]
         exec_config: headless::Config,
     },
+    Debug {
+        /// Debug this rom
+        rom: PathBuf,
+    },
 }
 
 fn exec(name: &str, command: &mut Command) -> Output {
@@ -100,6 +110,7 @@ pub fn main() {
 
     let mut err = false;
     match config {
+        Config::Debug { rom } => debugger::run(&rom),
         Config::Term { exec_config } => terminal::run(exec_config),
         Config::Run { exec_config } => exit(run(exec_config)),
         Config::Golden { golden_path } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,6 @@ extern crate these;
 extern crate serde;
 extern crate ansi_escapes;
 extern crate rustyline;
-#[macro_use]
-extern crate rustyline_derive;
 extern crate shlex;
 
 #[cfg(test)]


### PR DESCRIPTION
Rustyline + structopt for a repl that pretends each read-eval is a CLI.
There is a basic expression language for dumping registers.

Right now `print` and `continue` is supported.

`debugger.rs` is a bit gross right now, but we can clean that up later.

https://imgur.com/a/4yeJTae